### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "machines",
     "machinepack"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mikermcneil/machinepack-redis.git"
+  },
   "author": "The Treeline Company",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
This will let people find [the GitHub repository](https://github.com/mikermcneil/machinepack-redis/) from [the npmjs page](https://www.npmjs.com/package/machinepack-redis). You will need to republish to npm after making these changes in order for them to take effect.